### PR TITLE
Add --by-file option

### DIFF
--- a/cli.yml
+++ b/cli.yml
@@ -36,3 +36,7 @@ args:
       conflicts_with:
           - input
       help: prints out supported languages and their extensions
+  - byfile:
+      long: by-file
+      takes_value: false
+      help: Report results for every source file encountered.

--- a/src/language.rs
+++ b/src/language.rs
@@ -19,6 +19,7 @@ pub struct Language<'a> {
     pub lines: usize,
     pub total: usize,
     pub printed: bool,
+    pub format_offset: usize,
 }
 
 
@@ -95,9 +96,15 @@ impl<'a> fmt::Display for Language<'a> {
         } else {
             self.total
         };
+        let offset = if self.format_offset == 0 {
+            18
+        } else {
+            self.format_offset
+        };
         write!(f,
-               " {: <18} {: >6} {:>12} {:>12} {:>12} {:>12}",
+               " {: <1$} {2: >6} {3:>12} {4:>12} {5:>12} {6:>12}",
                self.name,
+               offset,
                total,
                self.lines,
                self.blanks,


### PR DESCRIPTION
add `--by-file` option.
If use this option, to obtain the results of each file.

for example:
```
$ ~/work/tokei.hhatto/target/release/tokei --by-file .
------------------------------------------------------------------------------
 File                   Files     Total       Blanks     Comments         Code
------------------------------------------------------------------------------
 ./CHANGELOG.md                       0            0            0           20
 ./CONTRIBUTING.md                    0            0            0           25
 ./CONTRIBUTORS.md                    0            0            0           12
 ./README.md                          0            0            0          169
 ./src/fsutil.rs                     51            6            5           42
 ./src/language.rs                  107           13            5           90
 ./src/macros.rs                     21            2            3           16
 ./src/main.rs                      456           43            5          408
 ./Cargo.toml                        24            3            3           18
 ./.travis.yml                       13            1            0           12
 ./cli.yml                           38            0            3           35
------------------------------------------------------------------------------
 Total                  11          710           68           24          847
------------------------------------------------------------------------------
```

The reason for adding this option, because I want to use the [SLOCCount Plugin in the Jenkins CI](https://wiki.jenkins-ci.org/display/JENKINS/SLOCCount+Plugin).
If possible I would like to also add `--xml` option in the future.

Thanks