### PR TITLE
another few clippy warnings fixed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn main() {
 
     // Print every supported language.
     if matches.is_present("languages") {
-        for (_, language) in &languages {
+        for language in languages.values() {
             let mut language = language.borrow_mut();
             if !language.printed {
                 println!("{:<25}", language.name);
@@ -231,7 +231,7 @@ fn main() {
     get_all_files(paths, &languages, ignored_directories);
 
     let mut total = Language::new_raw("Total");
-    for (_, language) in &languages {
+    for language in languages.values() {
 
         if language.borrow().printed {
             continue;
@@ -279,7 +279,7 @@ fn main() {
                     continue;
                 }
 
-                let single_comments = language.borrow().line_comment.split(",");
+                let single_comments = language.borrow().line_comment.split(',');
 
                 for single in single_comments {
                     if line.starts_with(single) {


### PR DESCRIPTION
Using the `languages.values()` iterator may save some time/space, as does using a character as pattern instead of a one-character string. 