### PR TITLE
Prints code lines before comments and blanks

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -108,11 +108,11 @@ impl Language {
     pub fn print(&self, name: LanguageName) {
         println!(" {: <18} {: >6} {:>12} {:>12} {:>12} {:>12}",
                  name.name(),
-                 self.total,
+                 self.total, // files count
                  self.lines,
-                 self.blanks,
+                 self.code,
                  self.comments,
-                 self.code)
+                 self.blanks)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,10 +146,10 @@ fn main() {
     println!(" {:<12} {:>12} {:>12} {:>12} {:>12} {:>12}",
              "Language",
              "Files",
-             "Total",
-             "Blanks",
+             "Lines",
+             "Code",
              "Comments",
-             "Code");
+             "Blanks");
     println!("{}", ROW);
 
     get_all_files(paths, &mut languages, ignored_directories);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -30,8 +30,8 @@ impl fmt::Display for Stats {
                " {: <25} {:>12} {:>12} {:>12} {:>12}",
                name,
                self.lines,
-               self.blanks,
+               self.code,
                self.comments,
-               self.code)
+               self.blanks)
     }
 }


### PR DESCRIPTION
Most users are more concerned about code lines than comments or blanks.