### PR TITLE
fix for no-comment languages: Json, Markdown, Text

### DIFF
--- a/src/main.rs.in
+++ b/src/main.rs.in
@@ -228,6 +228,8 @@ fn main() {
 
             if language.is_blank() {
                 stats.code += lines.count();
+                stats.lines += stats.code;
+                *language += stats;
                 continue;
             }
 


### PR DESCRIPTION
Currently (before this commit) those languages' code lines are just ignored by mistake.