### PR TITLE
Fixes issue #52

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,5 +8,6 @@ The list of languages is sorted alphabetical.
 * Chris Palmer (https://github.com/PhnxRbrn)
 * Aaron Power (https://github.com/Aaronepower)
 * Luthaf (https://github.com/Luthaf)
+* Matthew Williamson (https://github.com/mwilli20)
 
 ## Translations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Aaronepower <theaaronepower@gmail.com>"]
 build = "src/lib/build.rs"
-description = "Count code, quickly."
+description = "A program that allows you to count code, quickly."
 homepage = "https://aaronepower.github.io/tokei/"
 include = ["src/**/*", "cli.yml", "Cargo.toml", "LICENCE-APACHE", "LICENCE-MIT"]
 license = "MIT/Apache-2.0"

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -253,18 +253,21 @@ impl Languages {
         let map = btreemap! {
             ActionScript => Language::new_c(),
             Ada => Language::new_single(vec!["--"]),
-            Assembly => Language::new_single(vec![";"]),
+            Assembly => Language::new_single(vec![";"])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Asp => Language::new_single(vec!["'", "REM"]),
             AspNet => Language::new_multi(vec![("<!--", "-->"), ("<%--", "-->")]),
             Autoconf => Language::new_single(vec!["#", "dnl"]),
-            Bash => Language::new_hash(),
-            Batch => Language::new_single(vec!["REM"]),
+            Bash => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Batch => Language::new_single(vec!["REM", "::"]).set_quotes(vec![]),
             C => Language::new_c(),
             CHeader => Language::new_c(),
             Clojure => Language::new_single(vec![";"]),
             CoffeeScript => Language::new(vec!["#"], vec![("###", "###")])
-                                     .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            ColdFusion => Language::new_multi(vec![("<!---", "--->")]),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            ColdFusion => Language::new_multi(vec![("<!---", "--->")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             ColdFusionScript => Language::new_c(),
             Coq => Language::new_func(),
             Cpp => Language::new_c(),
@@ -272,22 +275,29 @@ impl Languages {
             CSharp => Language::new_c(),
             CShell => Language::new_hash(),
             Css => Language::new_c()
-                            .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            D => Language::new(vec!["//"], vec![("/*", "*/")]).nested_comments(vec![("/+", "+/")]),
-            Dart => Language::new_c(),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            D => Language::new(vec!["//"], vec![("/*", "*/")])
+                .nested_comments(vec![("/+", "+/")])
+                .set_quotes(vec![("\"", "\""), ("`", "`")]),
+            Dart => Language::new_c()
+                .set_quotes(vec![("\"", "\""), ("'", "'"), ("\"\"\"", "\"\"\""), ("'''", "'''")]),
             DeviceTree => Language::new_c(),
             Erlang => Language::new_single(vec!["%"]),
-            Forth => Language::new(vec!["\\"], vec![("( ", ")")]),
-            FortranLegacy => Language::new_single(vec!["c","C","!","*"]),
-            FortranModern => Language::new_single(vec!["!"]),
+            Forth => Language::new(vec!["\\"], vec![("( ", ")")])
+                .set_quotes(vec![("\"", "\"")]),
+            FortranLegacy => Language::new_single(vec!["c","C","!","*"])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            FortranModern => Language::new_single(vec!["!"])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Go => Language::new_c(),
             Handlebars => Language::new_multi(vec![("<!--", "-->"), ("{{!", "}}")])
-                                   .set_quotes(vec![("\"", "\""), ("'", "'")]),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Haskell => Language::new(vec!["--"], vec![("{-", "-}")]),
             Html => Language::new_html()
-                             .set_quotes(vec![("\"", "\""), ("'", "'")]),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Hex => Language::new_blank(),
-            Idris => Language::new(vec!["--"], vec![("{-", "-}")]),
+            Idris => Language::new(vec!["--"], vec![("{-", "-}")])
+                .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
             IntelHex => Language::new_blank(),
             Isabelle => Language::new(
                 vec!["--"],
@@ -296,59 +306,75 @@ impl Languages {
                         ("‹","›"),
                         ("\\<open>", "\\<close>"),
                     ]
-            ),
+            ).set_quotes(vec![("''", "''")]),
             Jai => Language::new_c().nested(),
             Java => Language::new_c(),
             JavaScript => Language::new_c()
-                                   .set_quotes(vec![("\"", "\""), ("'", "'")]),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Json => Language::new_blank(),
             Jsx => Language::new_c()
-                            .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            Julia => Language::new(vec!["#"], vec![("#=", "=#")]).nested(),
-            Kotlin => Language::new_c().nested(),
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Julia => Language::new(vec!["#"], vec![("#=", "=#")]).nested()
+                .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
+            Kotlin => Language::new_c().nested()
+                .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
             Less => Language::new_c(),
             LinkerScript => Language::new_c(),
-            Lisp => Language::new(vec![";"], vec![("#|", "|#")]),
-            Lua => Language::new(vec!["--"], vec![("--[[", "]]")]),
+            Lisp => Language::new(vec![";"], vec![("#|", "|#")]).nested(),
+            Lua => Language::new(vec!["--"], vec![("--[[", "]]")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Makefile => Language::new_hash(),
             Markdown => Language::new_blank(),
-            Mustache => Language::new_multi(vec![("{{!", "}}")]),
-            Nim => Language::new_hash(),
+            Mustache => Language::new_multi(vec![("{{!", "}}")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Nim => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
             ObjectiveC => Language::new_c(),
             ObjectiveCpp => Language::new_c(),
             OCaml => Language::new_func(),
             Oz => Language::new_pro(),
             Pascal => Language::new_multi(
-                vec![("{", "}"), ("(*", "*)"), ("{", "*)"), ("(*", "}")]),
-            Perl => Language::new(vec!["#"], vec![("=pod", "=cut")]),
-            Php => Language::new(vec!["#", "//"], vec![("/*", "*/")]),
+                vec![("{", "}"), ("(*", "*)"), ("{", "*)"), ("(*", "}")])
+                .set_quotes(vec![("'", "'")]),
+            Perl => Language::new(vec!["#"], vec![("=pod", "=cut")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Php => Language::new(vec!["#", "//"], vec![("/*", "*/")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Polly => Language::new_html(),
             Prolog => Language::new_pro(),
             Protobuf => Language::new_single(vec!["//"]),
-            Python => Language::new(
-                vec!["#"], vec![("'''", "'''"), ("\"\"\"", "\"\"\"")]),
+            Python => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'"), ("\"\"\"", "\"\"\""), ("'''", "'''")]),
             Qcl => Language::new_c(),
             R => Language::new_hash(),
             Razor => Language::new_multi(vec![("<!--", "-->"), ("@*", "*@")]),
-            Ruby => Language::new(vec!["#"], vec![("=begin", "=end")]),
+            Ruby => Language::new(vec!["#"], vec![("=begin", "=end")])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             RubyHtml => Language::new_html(),
             Rust => Language::new_c().nested(),
             ReStructuredText => Language::new_blank(),
-            Sass => Language::new_c(),
+            Sass => Language::new_c()
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Scala => Language::new_c(),
             Sml => Language::new_func(),
-            Sql => Language::new(vec!["--"], vec![("/*", "*/")]),
+            Sql => Language::new(vec!["--"], vec![("/*", "*/")])
+                .set_quotes(vec![("'", "'")]),
             Swift => Language::new_c().nested(),
             Tex => Language::new_single(vec!["%"]),
             Text => Language::new_blank(),
-            Toml => Language::new_hash(),
-            TypeScript => Language::new_c(),
+            Toml => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'"), ("\"\"\"", "\"\"\""), ("'''", "'''")]),
+            TypeScript => Language::new_c()
+                .set_quotes(vec![("\"", "\""), ("'", "'"), ("`", "`")]),
             UnrealScript => Language::new_c(),
-            VimScript => Language::new_single(vec!["\""]),
+            VimScript => Language::new_single(vec!["\""])
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Wolfram => Language::new_func(),
             Xml => Language::new_html(),
-            Yaml => Language::new_hash(),
-            Zsh => Language::new_hash(),
+            Yaml => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Zsh => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
         };
 
         Languages { inner: map }

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -72,11 +72,7 @@ fn count_files(language_tuple: &mut (&LanguageType, &mut Language)) {
             // FORTRAN has a rule where it only counts as a comment if it's the first
             // character in the column, so removing starting whitespace could cause a
             // miscount.
-            let line = if is_fortran {
-                line
-            } else {
-                line.trim_left()
-            };
+            let line = if is_fortran { line } else { line.trim_left() };
 
             if line.trim().is_empty() {
                 stats.blanks += 1;
@@ -265,7 +261,7 @@ impl Languages {
             Batch => Language::new_single(vec!["REM"]),
             C => Language::new_c(),
             CHeader => Language::new_c(),
-            Clojure => Language::new_single(vec![";","#"]),
+            Clojure => Language::new_single(vec![";"]),
             CoffeeScript => Language::new(vec!["#"], vec![("###", "###")])
                                      .set_quotes(vec![("\"", "\""), ("'", "'")]),
             ColdFusion => Language::new_multi(vec![("<!---", "--->")]),
@@ -281,13 +277,13 @@ impl Languages {
             Dart => Language::new_c(),
             DeviceTree => Language::new_c(),
             Erlang => Language::new_single(vec!["%"]),
-            Forth => Language::new(vec!["\\"], vec![("(", ")")]),
+            Forth => Language::new(vec!["\\"], vec![("( ", ")")]),
             FortranLegacy => Language::new_single(vec!["c","C","!","*"]),
             FortranModern => Language::new_single(vec!["!"]),
             Go => Language::new_c(),
             Handlebars => Language::new_multi(vec![("<!--", "-->"), ("{{!", "}}")])
                                    .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            Haskell => Language::new_single(vec!["--"]),
+            Haskell => Language::new(vec!["--"], vec![("{-", "-}")]),
             Html => Language::new_html()
                              .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Hex => Language::new_blank(),
@@ -301,15 +297,15 @@ impl Languages {
                         ("\\<open>", "\\<close>"),
                     ]
             ),
-            Jai => Language::new_c(),
+            Jai => Language::new_c().nested(),
             Java => Language::new_c(),
             JavaScript => Language::new_c()
                                    .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Json => Language::new_blank(),
             Jsx => Language::new_c()
                             .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            Julia => Language::new(vec!["#"], vec![("#=", "=#")]),
-            Kotlin => Language::new_c(),
+            Julia => Language::new(vec!["#"], vec![("#=", "=#")]).nested(),
+            Kotlin => Language::new_c().nested(),
             Less => Language::new_c(),
             LinkerScript => Language::new_c(),
             Lisp => Language::new(vec![";"], vec![("#|", "|#")]),
@@ -322,13 +318,15 @@ impl Languages {
             ObjectiveCpp => Language::new_c(),
             OCaml => Language::new_func(),
             Oz => Language::new_pro(),
-            Pascal => Language::new(vec!["//","(*"], vec![("{", "}")]),
-            Perl => Language::new(vec!["#"], vec![("=", "=cut")]),
-            Php => Language::new(vec!["#","//"], vec![("/*", "*/")]),
+            Pascal => Language::new_multi(
+                vec![("{", "}"), ("(*", "*)"), ("{", "*)"), ("(*", "}")]),
+            Perl => Language::new(vec!["#"], vec![("=pod", "=cut")]),
+            Php => Language::new(vec!["#", "//"], vec![("/*", "*/")]),
             Polly => Language::new_html(),
             Prolog => Language::new_pro(),
             Protobuf => Language::new_single(vec!["//"]),
-            Python => Language::new(vec!["#"], vec![("'''", "'''")]),
+            Python => Language::new(
+                vec!["#"], vec![("'''", "'''"), ("\"\"\"", "\"\"\"")]),
             Qcl => Language::new_c(),
             R => Language::new_hash(),
             Razor => Language::new_multi(vec![("<!--", "-->"), ("@*", "*@")]),
@@ -340,7 +338,7 @@ impl Languages {
             Scala => Language::new_c(),
             Sml => Language::new_func(),
             Sql => Language::new(vec!["--"], vec![("/*", "*/")]),
-            Swift => Language::new_c(),
+            Swift => Language::new_c().nested(),
             Tex => Language::new_single(vec!["%"]),
             Text => Language::new_blank(),
             Toml => Language::new_hash(),


### PR DESCRIPTION
Sorry about the last branch, I forgot I made the in github edit, and couldn't figure out what was wrong.
In response to the Php strings, they have a new string type in Php 5.

<<<EOD
Example of string
spanning multiple lines
using heredoc syntax.
EOD;

<<< Starts the comment, and then gets a variable name, and doesn't end until that variable name comes up again.