### PR TITLE
support tcl

### DIFF
--- a/src/lib/language/language_type.rs
+++ b/src/lib/language/language_type.rs
@@ -159,6 +159,8 @@ pub enum LanguageType {
     Sql,
     /// Swift
     Swift,
+    /// Tcl
+    Tcl,
     /// Tex
     Tex,
     /// Text
@@ -265,6 +267,7 @@ impl LanguageType {
             Sml => "Standard ML",
             Sql => "SQL",
             Swift => "Swift",
+            Tcl => "TCL",
             Tex => "TeX",
             Text => "Plain Text",
             Toml => "TOML",
@@ -363,6 +366,7 @@ impl LanguageType {
                 "sml" => Some(Sml),
                 "sql" => Some(Sql),
                 "swift" => Some(Swift),
+                "tcl" => Some(Tcl),
                 "tex" | "sty" => Some(Tex),
                 "toml" => Some(Toml),
                 "ts" => Some(TypeScript),

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -363,6 +363,8 @@ impl Languages {
             Sql => Language::new(vec!["--"], vec![("/*", "*/")])
                 .set_quotes(vec![("'", "'")]),
             Swift => Language::new_c().nested(),
+            Tcl => Language::new_hash()
+                .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Tex => Language::new_single(vec!["%"]),
             Text => Language::new_blank(),
             Toml => Language::new_hash()


### PR DESCRIPTION
TCL is also known as [Tool Command Language](https://fr.wikipedia.org/wiki/Tool_Command_Language).

Example:

```
$ time target/release/tokei ~/ws -s code
-------------------------------------------------------------------------------
 Language            Files        Lines         Code     Comments       Blanks
-------------------------------------------------------------------------------
 TCL                 11232     14295483     11399104      1071421      1824958
 Plain Text             92        69131        69131            0            0
 Python                193        36349        28551         2123         5675
 JSON                   32        15192        15192            0            0
 XML                   103        15666        15065            0          601
 Ruby                   28        15330        14302          916          112
 BASH                  105        10815         6305         2450         2060
 ASP.Net                 1         7278         6250            0         1028
 Java                   49         6829         4972          521         1336
 Perl                   20         4396         2745          996          655
 C                       6         1416         1185           35          196
 PHP                     2          543          514           16           13
 YAML                    1          239          207            0           32
 C Header                2           78           55            9           14
 Markdown                1           29           29            0            0
 Makefile                1           42           24            4           14
-------------------------------------------------------------------------------
 Total               11868     14478816     11563631      1078491      1836694
-------------------------------------------------------------------------------
target/release/tokei ~/ws -s code  14.06s user 0.32s system 100% cpu 14.359 total
```

It's pretty close to `cloc`, but somehow if find more files (and it's also so much faster!):

```
time cloc ~/ws
   19785 text files.
   16992 unique files.                                          
    8173 files ignored.

github.com/AlDanial/cloc v 1.70  T=148.46 s (78.8 files/s, 97010.5 lines/s)
--------------------------------------------------------------------------------
Language                      files          blank        comment           code
--------------------------------------------------------------------------------
Tcl/Tk                        11158        1823027        1069494       11395199
Python                          189           5367           4037          25310
XML                             103            601            123          14942
JSON                             30             74              0          13930
Expect                           19           1981           1591           8742
Ruby                              8             56            458           7151
ASP.Net                           1           1028              0           6250
Bourne Shell                     97           1919           2071           5924
Java                             48           1317            524           4877
Perl                             12            415            451           2130
C                                 6            196             64           1156
XSD                               3             60             21            827
PHP                               2             13             15            515
YAML                              1             32              0            207
Bourne Again Shell                5             17             28            107
awk                               4             39             21             85
C/C++ Header                      2             14             14             50
make                              1             14              4             24
Markdown                          1              8              0             21
sed                               2              1              3              5
--------------------------------------------------------------------------------
SUM:                          11692        1836179        1078919       11487452
--------------------------------------------------------------------------------
cloc ~/ws  99.03s user 15.69s system 77% cpu 2:28.73 total
```

