### PR TITLE
Add support for lean

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Julia
 JSON
 JSX
 Kotlin
+Lean
 LESS
 LD Script
 LISP

--- a/src/lib/language/language_type.rs
+++ b/src/lib/language/language_type.rs
@@ -97,6 +97,8 @@ pub enum LanguageType {
     Jsx,
     /// Kotlin
     Kotlin,
+    /// Lean
+    Lean,
     /// Less
     Less,
     /// LinkerScript
@@ -236,6 +238,7 @@ impl LanguageType {
             Jsx => "JSX",
             Julia => "Julia",
             Kotlin => "Kotlin",
+            Lean => "Lean",
             Less => "LESS",
             LinkerScript => "LD Script",
             Lisp => "LISP",
@@ -335,6 +338,7 @@ impl LanguageType {
                 "jsx" => Some(Jsx),
                 "kt" | "kts" => Some(Kotlin),
                 "lds" => Some(LinkerScript),
+                "lean" | "hlean" => Some(Lean),
                 "less" => Some(Less),
                 "lua" => Some(Lua),
                 "m" => Some(ObjectiveC),
@@ -439,6 +443,7 @@ impl<'a> From<&'a str> for LanguageType {
             "Json" => Json,
             "Jsx" => Jsx,
             "Kotlin" => Kotlin,
+            "Lean" => Lean,
             "Less" => Less,
             "LinkerScript" => LinkerScript,
             "Lisp" => Lisp,

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -321,6 +321,7 @@ impl Languages {
                 .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
             Kotlin => Language::new_c().nested()
                 .set_quotes(vec![("\"", "\""), ("\"\"\"", "\"\"\"")]),
+            Lean => Language::new(vec!["--"], vec![("/-", "-/")]).nested(),
             Less => Language::new_c(),
             LinkerScript => Language::new_c(),
             Lisp => Language::new(vec![";"], vec![("#|", "|#")]).nested(),

--- a/src/lib/utils/multi_line.rs
+++ b/src/lib/utils/multi_line.rs
@@ -66,9 +66,11 @@ pub fn handle_multi_line(line: &str,
         }
 
 
-        for comment in &language.line_comment {
-            if window.starts_with(comment) {
-                break 'window;
+        if stack.is_empty() {
+            for comment in &language.line_comment {
+                if window.starts_with(comment) {
+                    break 'window;
+                }
             }
         }
 
@@ -114,6 +116,15 @@ mod tests {
         let mut quote = None;
         let language = Language::new_c();
         handle_multi_line("Hello World // /*", &language, &mut stack, &mut quote);
+        assert_eq!(stack.len(), 0);
+    }
+
+    #[test]
+    fn single_comment_in_multi() {
+        let mut stack = vec![];
+        let mut quote = None;
+        let language = Language::new_c();
+        handle_multi_line("Hello /* // */ world", &language, &mut stack, &mut quote);
         assert_eq!(stack.len(), 0);
     }
 


### PR DESCRIPTION
This PR adds support for [Lean](https://leanprover.github.io/) source files.

Futhermore I have slightly modified the handling of nested single-line comments.  In at least Haskell and C  (and also Lean) line comments are ignored if they occur inside a multi-line comment.  For example the following programs both work:
```haskell
{- -- -}
main = putStrLn "Hello, world!"
```
```c
/* // */
#include <stdio.h>
int main(int argc, char **argv) { printf("Hello, world!\n"); return 0; }
```

I don't know if any other language handles this differently.