### PR TITLE
Add support for elm

### DIFF
--- a/src/lib/language/language_type.rs
+++ b/src/lib/language/language_type.rs
@@ -59,6 +59,8 @@ pub enum LanguageType {
     Dart,
     /// DeviceTree
     DeviceTree,
+    /// Elm
+    Elm,
     /// Erlang
     Erlang,
     /// Forth
@@ -183,8 +185,6 @@ pub enum LanguageType {
     Yaml,
     /// Zsh
     Zsh,
-    /// Elm
-    Elm
 }
 
 impl LanguageType {
@@ -221,6 +221,7 @@ impl LanguageType {
             D => "D",
             Dart => "Dart",
             DeviceTree => "Device Tree",
+            Elm => "Elm",
             Erlang => "Erlang",
             Forth => "Forth",
             FortranLegacy => "FORTRAN Legacy",
@@ -283,7 +284,6 @@ impl LanguageType {
             Xml => "XML",
             Yaml => "YAML",
             Zsh => "Zsh",
-            Elm => "Elm"
         }
     }
 
@@ -318,6 +318,7 @@ impl LanguageType {
                 "dart" => Some(Dart),
                 "dts" | "dtsi" => Some(DeviceTree),
                 "el" | "lisp" | "lsp" => Some(Lisp),
+                "elm" => Some(Elm),
                 "erl" | "hrl" => Some(Erlang),
                 "4th" | "forth" | "fr" | "frt" | "fth" | "f83" | "fb" | "fpm" | "e4" | "rx" |
                 "ft" => Some(Forth),
@@ -385,7 +386,6 @@ impl LanguageType {
                 "xml" => Some(Xml),
                 "yaml" | "yml" => Some(Yaml),
                 "zsh" => Some(Zsh),
-                "elm" => Some(Elm),
                 extension => {
                     warn!("Unknown extension: {}", extension);
                     None
@@ -429,6 +429,7 @@ impl<'a> From<&'a str> for LanguageType {
             "D" => D,
             "Dart" => Dart,
             "DeviceTree" => DeviceTree,
+            "Elm" => Elm,
             "Erlang" => Erlang,
             "Forth" => Forth,
             "FortranLegacy" => FortranLegacy,
@@ -489,7 +490,6 @@ impl<'a> From<&'a str> for LanguageType {
             "Xml" => Xml,
             "Yaml" => Yaml,
             "Zsh" => Zsh,
-            "Elm" => Elm,
             _ => unreachable!(),
         }
     }

--- a/src/lib/language/language_type.rs
+++ b/src/lib/language/language_type.rs
@@ -183,6 +183,8 @@ pub enum LanguageType {
     Yaml,
     /// Zsh
     Zsh,
+    /// Elm
+    Elm
 }
 
 impl LanguageType {
@@ -281,6 +283,7 @@ impl LanguageType {
             Xml => "XML",
             Yaml => "YAML",
             Zsh => "Zsh",
+            Elm => "Elm"
         }
     }
 
@@ -382,6 +385,7 @@ impl LanguageType {
                 "xml" => Some(Xml),
                 "yaml" | "yml" => Some(Yaml),
                 "zsh" => Some(Zsh),
+                "elm" => Some(Elm),
                 extension => {
                     warn!("Unknown extension: {}", extension);
                     None
@@ -485,6 +489,7 @@ impl<'a> From<&'a str> for LanguageType {
             "Xml" => Xml,
             "Yaml" => Yaml,
             "Zsh" => Zsh,
+            "Elm" => Elm,
             _ => unreachable!(),
         }
     }

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -285,6 +285,7 @@ impl Languages {
             Dart => Language::new_c()
                 .set_quotes(vec![("\"", "\""), ("'", "'"), ("\"\"\"", "\"\"\""), ("'''", "'''")]),
             DeviceTree => Language::new_c(),
+            Elm => Language::new(vec!["--"], vec![("{-", "-}")]).nested(),
             Erlang => Language::new_single(vec!["%"]),
             Forth => Language::new(vec!["\\"], vec![("( ", ")")])
                 .set_quotes(vec![("\"", "\"")]),
@@ -381,7 +382,6 @@ impl Languages {
                 .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Zsh => Language::new_hash()
                 .set_quotes(vec![("\"", "\""), ("'", "'")]),
-            Elm => Language::new(vec!["--"], vec![("{-", "-}")]).nested(),
         };
 
         Languages { inner: map }

--- a/src/lib/language/languages.rs
+++ b/src/lib/language/languages.rs
@@ -381,6 +381,7 @@ impl Languages {
                 .set_quotes(vec![("\"", "\""), ("'", "'")]),
             Zsh => Language::new_hash()
                 .set_quotes(vec![("\"", "\""), ("'", "'")]),
+            Elm => Language::new(vec!["--"], vec![("{-", "-}")]).nested(),
         };
 
         Languages { inner: map }


### PR DESCRIPTION
This PR adds support for Elm language. 

I just copy-pasted haskell's comment style, it's right for Elm's syntax, hope it's right from tokei's point. 