### PR TITLE
long verbose arg name

### DIFF
--- a/cli.yml
+++ b/cli.yml
@@ -49,5 +49,6 @@ args:
         takes_value: true
     - verbose:
         help: 'Set verbose output level: 1 for File IO errors 2: for unknown extensions'
+        long: verbose
         short: v
         multiple: true


### PR DESCRIPTION
```
Tokei 4.3.0
Aaron P. <theaaronepower@gmail.com>
Count Code, Quickly.

USAGE:
    Tokei [FLAGS] [OPTIONS] <input>...

FLAGS:
    -f, --files        Will print out statistics on individual files.
    -h, --help         Prints help information
    -l, --languages    Prints out supported languages and their extensions.
    -V, --version      Prints version information
    -v                 Set verbose output level: 1 for File IO errors 2: for unknown extensions
        ^^^^^^^^^
        |<---------------- No long name
```