### PR TITLE
Only add regular files to path list

### DIFF
--- a/src/lib/utils/fs.rs
+++ b/src/lib/utils/fs.rs
@@ -102,3 +102,27 @@ pub fn get_extension<P: AsRef<Path>>(path: P) -> Option<String> {
     }
 
 }
+
+
+#[cfg(test)]
+mod test {
+    extern crate tempdir;
+    use super::*;
+    use std::fs::create_dir;
+    use language::languages::Languages;
+    use language::LanguageType;
+    use self::tempdir::TempDir;
+
+
+    #[test]
+    fn walker_directory_as_file() {
+        let tmp_dir = TempDir::new("test").expect("Couldn't create temp dir");
+        let path_name = tmp_dir.path().join("directory.rs");
+        create_dir(&path_name).expect("Couldn't create directory.rs within temp");
+
+        let mut l = Languages::new();
+        get_all_files(vec![tmp_dir.into_path().to_str().unwrap()].into(), vec![].into(), &mut l);
+
+        assert_eq!(0, l.get(&LanguageType::Rust).unwrap().files.len());
+    }
+}

--- a/src/lib/utils/fs.rs
+++ b/src/lib/utils/fs.rs
@@ -48,7 +48,7 @@ pub fn get_all_files<'a>(paths: Cow<'a, [&'a str]>,
                         get_language!(languages, &path)
                     };
 
-                    if path.metadata().unwrap().is_file() {
+                    if rs_error!(path.metadata()).is_file() {
                         language.files.push(path.to_owned());
                     }
                 }
@@ -74,7 +74,7 @@ pub fn get_all_files<'a>(paths: Cow<'a, [&'a str]>,
                     get_language!(languages, entry.path())
                 };
 
-                if entry.metadata().unwrap().is_file() {
+                if rs_error!(entry.metadata()).is_file() {
                     language.files.push(entry.path().to_owned());
                 }
             }

--- a/src/lib/utils/fs.rs
+++ b/src/lib/utils/fs.rs
@@ -48,7 +48,9 @@ pub fn get_all_files<'a>(paths: Cow<'a, [&'a str]>,
                         get_language!(languages, &path)
                     };
 
-                    language.files.push(path.to_owned());
+                    if path.metadata().unwrap().is_file() {
+                        language.files.push(path.to_owned());
+                    }
                 }
             }
         } else {
@@ -72,7 +74,9 @@ pub fn get_all_files<'a>(paths: Cow<'a, [&'a str]>,
                     get_language!(languages, entry.path())
                 };
 
-                language.files.push(entry.path().to_owned());
+                if entry.metadata().unwrap().is_file() {
+                    language.files.push(entry.path().to_owned());
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes multiple issues. Before this commit, a directory with
a known file extension in its name would be added to the list of
"files" to open and read from. Another issue occurred with broken
symbolic links being added to the files list.