### PR TITLE
Exit gracefully instead of panicking when using a feature that isn't compiled in

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 #[macro_use]
 extern crate clap;
+#[macro_use]
 extern crate log;
 extern crate env_logger;
 // #[cfg(feature = "cbor")]
@@ -22,6 +23,7 @@ use std::borrow::Cow;
 #[cfg(feature = "io")]
 use std::collections::BTreeMap;
 use std::thread;
+use std::error::Error;
 use std::time::Duration;
 use std::sync::mpsc::channel;
 use std::io::{Write, stderr};
@@ -249,7 +251,9 @@ fn add_input(input: &str, languages: &mut Languages) {
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 fn add_input(input: &str, map: &mut Languages) -> ! {
-    write!(stderr(), "{}", OUTPUT_ERROR);
+    if let Err(error) = write!(stderr(), "{}", OUTPUT_ERROR) {
+        error!("{}", error.description());
+    }
     std::process::exit(1);
 }
 
@@ -291,7 +295,9 @@ fn match_output(format: &str, languages: &Languages) {
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 fn match_output(format: &str, languages: &Languages) -> ! {
-    write!(stderr(), "{}", OUTPUT_ERROR);
+    if let Err(error) = write!(stderr(), "{}", OUTPUT_ERROR) {
+        error!("{}", error.description());
+    }
     std::process::exit(1);
 }
 
@@ -299,7 +305,9 @@ fn match_output(format: &str, languages: &Languages) -> ! {
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 pub fn convert_input(contents: String) -> ! {
-    write!(stderr(), "{}", OUTPUT_ERROR);
+    if let Err(error) = write!(stderr(), "{}", OUTPUT_ERROR) {
+        error!("{}", error.description());
+    }
     std::process::exit(1);
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeMap;
 use std::thread;
 use std::time::Duration;
 use std::sync::mpsc::channel;
+use std::io::{Write, stderr};
 
 use clap::App;
 use log::LogLevelFilter;
@@ -248,7 +249,9 @@ fn add_input(input: &str, languages: &mut Languages) {
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 fn add_input(input: &str, map: &mut Languages) -> ! {
-    panic!(OUTPUT_ERROR)
+    write!(stderr(), "{}", OUTPUT_ERROR);
+    std::process::exit(1);
+
 }
 
 
@@ -289,14 +292,16 @@ fn match_output(format: &str, languages: &Languages) {
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 fn match_output(format: &str, languages: &Languages) -> ! {
-    panic!(OUTPUT_ERROR)
+    write!(stderr(), "{}", OUTPUT_ERROR);
+    std::process::exit(1);
 }
 
 
 #[cfg(not(feature = "io"))]
 #[allow(unused_variables)]
 pub fn convert_input(contents: String) -> ! {
-    panic!(OUTPUT_ERROR);
+    write!(stderr(), "{}", OUTPUT_ERROR);
+    std::process::exit(1);
 }
 
 fn print_language<'a, C>(language: &'a Language, name: C)

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,6 @@ fn add_input(input: &str, languages: &mut Languages) {
 fn add_input(input: &str, map: &mut Languages) -> ! {
     write!(stderr(), "{}", OUTPUT_ERROR);
     std::process::exit(1);
-
 }
 
 


### PR DESCRIPTION
At the moment if you try to output in a particular format and forgot to compile with that feature, the program will just panic.

```
$ tokei src --output json
thread 'main' panicked at 'This version of tokei was compiled without any serialization
    formats, to enable serialization, reinstall tokei with the features flag.

        cargo install tokei --features all
', /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/tokei-4.4.0/src/main.rs:292
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Although the error message tells you exactly what the problem is and how to fix it, it would still be a lot nicer in terms of end user experience to print the error message to stderr and then exit. Normally when I see that a program has panicked it's because of a bug or an error which can't be recovered from, whereas this is just a case of you not having included a certain feature when installing.