### PR TITLE
Differentiate between bash and sh

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -78,6 +78,26 @@
                 "in"
             ]
         },
+        "Sh":{
+            "name":"sh",
+            "base":"hash",
+            "quotes":[
+                [
+                    "\\\"",
+                    "\\\""
+                ],
+                [
+                    "'",
+                    "'"
+                ]
+            ],
+            "env":[
+                "sh"
+            ],
+            "extensions":[
+                "sh"
+            ]
+        },
         "Bash":{
             "name":"BASH",
             "base":"hash",
@@ -92,12 +112,10 @@
                 ]
             ],
             "env":[
-                "bash",
-                "sh"
+                "bash"
             ],
             "extensions":[
-                "bash",
-                "sh"
+                "bash"
             ]
         },
         "Batch":{


### PR DESCRIPTION
It is more accurate to not consider bash and sh to be the same.  Bash is
a superset of sh. Same goes for tcsh, zsh, fish, rc, es, etc.