### PR TITLE
Extend Standard ML name

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1109,7 +1109,7 @@
             ]
         },
         "Sml":{
-            "name":"Standard ML",
+            "name":"Standard ML (SML)",
             "base":"func",
             "extensions":[
                 "sml"


### PR DESCRIPTION
Since Standard ML is equally often if not more referred to as SML, it
makes sense to include "(SML)" in the display name.