### PR TITLE
fixed `--languages` option always conflicting with input

### DIFF
--- a/cli.yml
+++ b/cli.yml
@@ -29,7 +29,6 @@ args:
         index: 1
         multiple: true
         required: true
-        default_value: "."
     - languages:
         conflicts_with:
             - input

--- a/cli.yml
+++ b/cli.yml
@@ -28,7 +28,6 @@ args:
         help: The input file(s)/directory(ies)
         index: 1
         multiple: true
-        required: true
     - languages:
         conflicts_with:
             - input

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,10 @@ fn main() {
         return;
     }
 
-    let paths: Vec<&str> = matches.values_of("input").unwrap().collect();
+    let paths: Vec<&str> = match matches.values_of("input") {
+        Some(vs) => vs.collect(),
+        None => vec!["."],
+    };
 
     if let Some(input) = input_option {
         add_input(input, &mut languages);


### PR DESCRIPTION
As defined in `cli.yml`, `--languages` conflicts with `<input>`,
but if `<input>` has default value, `--languages` will always conflict,
even if no inputs were specified.

Computation of the default value for `<input>` is now moved to `src/main.rs`,
because it cannot be specified in `cli.yml` along with `--languages`.

I suspect this bug was introduced in commit b7a892f4753d, when default
value for `<input>` was added.