### PR TITLE
Allow multiple --exclude options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         (version: crate_version!())
         (author: "Aaron P. <theaaronepower@gmail.com> + Contributors")
         (about: crate_description!())
-        (@arg exclude: -e --exclude +takes_value "Ignore all files & directories containing the word.")
+        (@arg exclude: -e --exclude +takes_value ... "Ignore all files & directories containing the word.")
         (@arg file_input: -i --input +takes_value "Gives statistics from a previous tokei run. Can be given a file path, or \"stdin\" to read from stdin.")
         (@arg files: -f --files "Will print out statistics on individual files.")
         (@arg input: conflicts_with[languages] ... "The input file(s)/directory(ies) to be counted.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         (version: crate_version!())
         (author: "Aaron P. <theaaronepower@gmail.com> + Contributors")
         (about: crate_description!())
-        (@arg exclude: -e --exclude +takes_value ... "Ignore all files & directories containing the word.")
+        (@arg exclude: -e --exclude +takes_value +multiple number_of_values(1) "Ignore all files & directories containing the word.")
         (@arg file_input: -i --input +takes_value "Gives statistics from a previous tokei run. Can be given a file path, or \"stdin\" to read from stdin.")
         (@arg files: -f --files "Will print out statistics on individual files.")
         (@arg input: conflicts_with[languages] ... "The input file(s)/directory(ies) to be counted.")


### PR DESCRIPTION
There is no reason *not* to allow multiple exclude values.
Multiple exclude options are processed correctly by [src/main.rs#L54-L55](https://github.com/m1el/tokei/blob/c0cb7427b440307f0ffd73d51992042ac3d392d1/src/main.rs#L54-L55), but clap config doesn't accept multiple exclude options.
This pull request should cover #111.