### PR TITLE
Add tsx extension for typescript.

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1345,7 +1345,8 @@
                 ]
             ],
             "extensions":[
-                "ts"
+                "ts",
+                "tsx"
             ]
         },
         "UnrealScript":{


### PR DESCRIPTION
Note that, apparenlty, the build script generates an enum variant for each language.

The only way I could get it to compile was by naming the language `Typescript_JSX`.

There should probably be some plumbing to allow setting an additional name that's used for display. 

Fixes #126 