### PR TITLE
Add QML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Protocol Buffers
 PureScript
 Python
 QCL
+QML
 R
 Rakefile
 Razor

--- a/languages.json
+++ b/languages.json
@@ -921,6 +921,17 @@
                 "qcl"
             ]
         },
+        "Qml":{
+            "name":"QML",
+            "base": "c",
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "qml"
+            ]
+        },
         "R":{
             "base":"hash",
             "extensions":[

--- a/tests/data/qml.qml
+++ b/tests/data/qml.qml
@@ -1,0 +1,20 @@
+// 20 lines 11 code 5 comments 4 blanks
+
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+
+ApplicationWindow {
+    visible: true
+
+    /*
+     * Multiline comment
+     */
+    Text {
+        text: "string type 1"
+    }
+
+    // comment
+    function testfunc() {
+        console.log('string type 2');
+    }
+}


### PR DESCRIPTION
Adds [QML](https://doc.qt.io/qt-5/qtqml-syntax-basics.html) language support. 