### PR TITLE
Add the visual basic and msbuild language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -282,7 +282,18 @@
                 "cr"
             ]
         },
-
+        "Vb":{
+            "name":"Visual Basic",
+            "quotes":[
+                ["\\\"", "\\\""]
+            ],
+            "line_comment":[
+                "'"
+            ],
+            "extensions":[
+                "vb"
+            ]
+        },
         "CSharp":{
             "name":"C#",
             "base":"c",

--- a/languages.json
+++ b/languages.json
@@ -1218,6 +1218,17 @@
                 "xml"
             ]
         },
+        "MSBuild":{
+            "name":"MSBuild",
+            "base":"html",
+            "extensions":[
+                "csproj",
+                "vbproj",
+                "fsproj",
+                "props",
+                "targets"
+            ]
+        },
         "Yaml":{
             "name":"YAML",
             "base":"hash",

--- a/languages.json
+++ b/languages.json
@@ -1285,7 +1285,8 @@
                 "fsproj",
                 "props",
                 "targets"
-
+            ]
+        },
         "Xtend":{
             "base":"c",
             "quotes":[

--- a/languages.json
+++ b/languages.json
@@ -282,7 +282,7 @@
                 "cr"
             ]
         },
-        "Vb":{
+        "VisualBasic":{
             "name":"Visual Basic",
             "quotes":[
                 ["\\\"", "\\\""]
@@ -1218,7 +1218,7 @@
                 "xml"
             ]
         },
-        "MSBuild":{
+        "MsBuild":{
             "name":"MSBuild",
             "base":"html",
             "extensions":[

--- a/tests/data/MSBuild.csproj
+++ b/tests/data/MSBuild.csproj
@@ -1,0 +1,12 @@
+<!-- 12 lines 10 code 1 comments 1 blanks -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.2" />
+  </ItemGroup>
+</Project>

--- a/tests/data/visualbasic.vb
+++ b/tests/data/visualbasic.vb
@@ -1,0 +1,7 @@
+' 7 lines 4 code 2 comments 1 blanks
+Public Class C
+    Public Sub M()
+    ' This is a comment
+    End Sub
+
+End Class


### PR DESCRIPTION
I work on [Roslyn](https://github.com/dotnet/roslyn) and wanted to see how our VB usage compares to c# internally.  With this PR I get the following which seems about right.

```
-------------------------------------------------------------------------------
 Language            Files        Lines         Code     Comments       Blanks
-------------------------------------------------------------------------------
 Batch                  24          270          193           14           63
 C Header                1           15           10            1            4
 C#                   7956      2559827      2023968       218514       317345
 C++                     4          185          135           22           28
 F#                      2           96           63           10           23
 JSON                   61          869          869            0            0
 MSBuild               285        20983        19774          980          229
 Markdown              118        11687        11687            0            0
 Shell                  14          474          305           73           96
 Plain Text            157       480277       480277            0            0
 Visual Basic         3226      1809279      1424731       132636       251912
 XAML                   26         2957         2849           18           90
 XML                    59        20389        15997         1986         2406
-------------------------------------------------------------------------------
 Total               11933      4907308      3980858       354254       572196
-------------------------------------------------------------------------------
```