### PR TITLE
Use eprintln!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,11 +1,10 @@
 [root]
 name = "tokei"
-version = "6.1.1"
+version = "6.1.2"
 dependencies = [
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "errln 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -178,11 +177,6 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "errln"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fnv"
@@ -612,7 +606,6 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-"checksum errln 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba822d3275762d55fd527b698dcf8f233a488885ea5e75c683fb5fd94af946"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum futures 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a82bdc62350ca9d7974c760e9665102fc9d740992a528c2254aa930e53b783c4"
 "checksum globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "feeb1b6840809ef5efcf7a4a990bc4e1b7ee3df8cf9e2379a75aeb2ba42ac9c3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ lazy_static = "0.2"
 
 [dependencies]
 encoding = "0.2"
-errln = "0.1"
 ignore = "0.2"
 log = "0.3"
 rayon = "0.7"

--- a/src/input.rs
+++ b/src/input.rs
@@ -73,7 +73,7 @@ mod io {
         let hex = match Vec::from_hex(contents) {
             Ok(hex) => hex,
             Err(err) => {
-                errln!("{}", err.description());
+                eprintln!("{}", err.description());
                 process::exit(1)
             }
         };
@@ -167,12 +167,12 @@ mod io {
 ";
 
     pub fn add_input(input: &str, map: &mut Languages) -> ! {
-        errln!("{}", OUTPUT_ERROR);
+        eprintln!("{}", OUTPUT_ERROR);
         process::exit(1);
     }
 
     pub fn match_output(format: &str, languages: Languages) -> ! {
-        errln!("{}", OUTPUT_ERROR);
+        eprintln!("{}", OUTPUT_ERROR);
         process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 // found in the LICENCE-{APACHE, MIT} file.
 
 #[macro_use] extern crate clap;
-#[macro_use] extern crate errln;
 extern crate env_logger;
 extern crate log;
 extern crate tokei;


### PR DESCRIPTION
`eprint!` and `eprintln!` has been introduced on Rust 1.19.0.
They should provide same functionalities as `err!` and `errln!`.