### PR TITLE
Add support for .el, .ede, .org and .srt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Device Tree
 Dockerfile
 Elixir
 Elm
+Emacs Development Environment
+Emacs Lisp
 Erlang
 Forth
 F*
@@ -324,6 +326,7 @@ Nix
 OCaml
 Objective C
 Objective C++
+Org mode
 Oz
 Pascal
 Perl
@@ -345,6 +348,7 @@ Rust
 Sass
 Scala
 Scons
+SRecode Template
 Standard ML
 SQL
 SVG

--- a/languages.json
+++ b/languages.json
@@ -371,6 +371,15 @@
                 ["'", "'"]
             ]
         },
+        "Elisp":{
+            "name":"Emacs Lisp",
+            "line_comment":[
+                ";"
+            ],
+            "extensions":[
+                "el"
+            ]
+        },
         "Elixir":{
             "line_comment":[
                 "#"
@@ -390,6 +399,15 @@
             "base":"haskell",
             "extensions":[
                 "elm"
+            ]
+        },
+        "EmacsDevEnv":{
+            "name":"Emacs Dev Env",
+            "line_comment":[
+                ";"
+            ],
+            "extensions":[
+                "ede"
             ]
         },
         "Erlang":{
@@ -724,7 +742,6 @@
             ],
             "nested":true,
             "extensions":[
-                "el",
                 "lisp",
                 "lsp"
             ]
@@ -838,6 +855,14 @@
             "extensions":[
                 "ml",
                 "mli"
+            ]
+        },
+        "Org":{
+            "line_comment":[
+                "# "
+            ],
+            "extensions":[
+                "org"
             ]
         },
         "Oz":{
@@ -1080,6 +1105,15 @@
             ],
             "extensions":[
                 "sql"
+            ]
+        },
+        "SRecode":{
+            "name": "SRecode Template",
+            "line_comment":[
+                ";;"
+            ],
+            "extensions":[
+                "srt"
             ]
         },
         "Svg":{

--- a/tests/data/emacs_dev_env.ede
+++ b/tests/data/emacs_dev_env.ede
@@ -1,0 +1,16 @@
+;; 16 lines 6 code 7 comments 3 blanks
+
+;; This is an EDE Project file
+
+;; Object ede-proj-project
+;; EDE project file.
+(ede-proj-project "ede-proj-project"
+  :name "my-proj"
+  :version "1.0.0"
+  :file "Project.ede"
+  :targets (list
+))
+
+;; Local Variables:
+;; mode: emacs-lisp
+;; End:

--- a/tests/data/emacs_lisp.el
+++ b/tests/data/emacs_lisp.el
@@ -1,0 +1,21 @@
+;; 21 lines 11 code 6 comments 4 blanks
+
+                                        ; This is a comment line
+;; This too!
+;;; This 3!
+;;;; This 4!
+
+(setq some-global-var nil)              ;Comment
+
+;;;###autoload
+(defun some-fn ()
+  "Some function."
+  (interactive)
+  (message "I am some function"))
+
+(defun fundamental-mode ()
+  "Major mode not specialized for anything in particular.
+Other major modes are defined by comparison with this one."
+  (interactive)
+  (kill-all-local-variables)
+  (run-mode-hooks))

--- a/tests/data/org_mode.org
+++ b/tests/data/org_mode.org
@@ -1,0 +1,13 @@
+# 13 lines 7 code 2 comments 4 blanks
+
+#+TITLE: This is the title, not a comment
+
+# This is comment
+
+Some text
+
+* Heading 1
+:PROPERTIES:
+:CUSTOM_ID: heading-1
+:END:
+Text under heading 1

--- a/tests/data/srecode.srt
+++ b/tests/data/srecode.srt
@@ -1,0 +1,37 @@
+;; 37 lines 23 code 2 comments 12 blanks
+
+set escape_start "$"
+set escape_end "$"
+set mode "srecode-template-mode"
+set priority "70"
+
+set comment_start  ";;"
+set comment_end    ""
+set comment_prefix ";;"
+
+set SEPARATOR "----"
+
+set DOLLAR "$"
+
+context file
+
+prompt MAJORMODE "Major Mode for templates: " read srecode-read-major-mode-name
+prompt START "Escape Start Characters: " default "{{"
+prompt END "Escape End Characters: " default "}}"
+
+template empty :file :user :time :srt
+"Insert a skeleton for a template file."
+----
+$>:filecomment$
+
+set mode "$?MAJORMODE$"
+set escape_start "$?START$"
+set escape_end "$?END$"
+
+context file
+
+$^$
+
+
+;; end
+----


### PR DESCRIPTION
Add support for following file extensions:

- Emacs Lisp (.el)
- Emacs Development Environement (.ede)
- Org mode (.org)
- SRecode (.srt)