### PR TITLE
Add support for .psl, .e, .ckt, .sv, .svh, .vg, .vh, .irunargs, .xrunargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ PHP
 Polly
 Prolog
 Protocol Buffers
+PSL Assertions
 PureScript
 Python
 QCL
@@ -346,9 +347,12 @@ Sass
 Scala
 Scons
 Standard ML
+Specman e
+SPICE Netlists
 SQL
 SVG
 Swift
+SystemVerilog
 TCL
 TeX
 Plain Text
@@ -357,6 +361,8 @@ TypeScript
 Unreal Script
 Ur/Web
 Vala
+Verilog
+Verilog argument files
 VHDL
 Vim Script
 Wolfram

--- a/languages.json
+++ b/languages.json
@@ -906,6 +906,13 @@
                 "pro"
             ]
         },
+        "PSL":{
+            "name":"PSL Assertion",
+            "base":"c",
+            "extensions":[
+                "psl"
+            ]
+        },
         "Protobuf":{
             "name":"Protocol Buffers",
             "line_comment":[
@@ -1059,12 +1066,33 @@
                 "sconscript"
             ]
         },
-
         "Sml":{
             "name":"Standard ML (SML)",
             "base":"func",
             "extensions":[
                 "sml"
+            ]
+        },
+        "SpecmanE":{
+            "name":"Specman e",
+            "line_comment":[
+                "--",
+                "//"
+            ],
+            "multi_line":[
+              ["'>", "<'"]
+            ],
+            "extensions":[
+                "e"
+            ]
+        },
+        "Spice":{
+            "name":"Spice Netlist",
+            "line_comment":[
+                "*"
+            ],
+            "extensions":[
+                "ckt"
             ]
         },
         "Sql":{
@@ -1094,6 +1122,13 @@
             "nested":true,
             "extensions":[
                 "swift"
+            ]
+        },
+        "SystemVerilog":{
+            "base":"c",
+            "extensions":[
+                "sv",
+                "svh"
             ]
         },
         "Tcl":{
@@ -1180,6 +1215,20 @@
             "base":"c",
             "extensions":[
                 "vala"
+            ]
+        },
+        "Verilog":{
+            "base":"c",
+            "extensions":[
+                "vg",
+                "vh"
+            ]
+        },
+        "VerilogArgsFile":{
+            "name":"Verilog Args File",
+            "extensions":[
+                "irunargs",
+                "xrunargs"
             ]
         },
         "Vhdl":{


### PR DESCRIPTION
File formats:

- Property Specification Language (.psl)
- Specman E (.e)
- SPICE netlist (.ckt)
- SystemVerilog (.sv, .svh)
- Verilog (.vg, .vh)
- Verilog Run Argument files (.irunargs, .xrunargs)

_Note that .v files are **the default** for Verilog files, but at the moment that clashes with Coq files. How can that be resolved?_
