### PR TITLE
fix build with features enabled

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -171,7 +171,8 @@ mod io {
         process::exit(1);
     }
 
-    pub fn match_output(_format: &str, _languages: &Languages) -> ! {
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+    pub fn match_output(_format: &str, _languages: Languages) -> ! {
         eprintln!("{}", OUTPUT_ERROR);
         process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
     languages.get_statistics(&paths, ignored_directories);
 
     if let Some(format) = output_option {
-        match_output(format, &languages);
+        match_output(format, languages);
     }
 
     println!("{}", ROW);


### PR DESCRIPTION
Since 8817762d7b8f5cd10886147b828f95d19dc2a80a, build fails with any
features enabled..

```rust
error[E0308]: mismatched types
  --> src/main.rs:95:30
   |
95 |         match_output(format, &languages);
   |                              ^^^^^^^^^^
   |                              |
   |                              expected struct `tokei::Languages`, found reference
   |                              help: consider removing the borrow: `languages`
   |
   = note: expected type `tokei::Languages`
              found type `&tokei::Languages`
```

Problem is that when no features enabled, match_output() doesn't need
to "eat" `tokei::Languages`, but in real version of match_output it
must not be borrowed.

Fixes: https://github.com/Aaronepower/tokei/issues/177
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>