### PR TITLE
Refactor how compiled-in serialization formats are handled

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -127,16 +127,7 @@ supported_formats!(
             extern crate serde_cbor;
             extern crate hex;
 
-            use std::error::Error;
-            use std::process;
-
-            let hex: Vec<u8> = match hex::FromHex::from_hex(input) {
-                Ok(hex) => hex,
-                Err(err) => {
-                    eprintln!("{}", err.description());
-                    process::exit(1)
-                }
-            };
+            let hex: Vec<u8> = hex::FromHex::from_hex(input)?;
             serde_cbor::from_slice(&hex)?
         },
         |languages| {

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,6 +41,12 @@ macro_rules! supported_formats {
                 ]
             }
 
+            pub fn all_feature_names() -> &'static [&'static str] {
+                &[
+                    $( $feature ),+
+                ]
+            }
+
             pub fn not_supported() -> &'static [&'static str] {
                 &[
                     $(
@@ -105,12 +111,13 @@ macro_rules! supported_formats {
 any '{format}' serialization support, to enable serialization, \
 reinstall tokei with the features flag.
 
-    cargo install tokei --features {format}
+    cargo install tokei --features {feature}
 
 If you want to enable all supported serialization formats, you can use the 'all' feature.
 
     cargo install tokei --features all\n",
-                                format = stringify!($name))
+                                format = stringify!($name),
+                                feature = $feature)
                             );
                         }
                     ),+

--- a/src/input.rs
+++ b/src/input.rs
@@ -131,13 +131,10 @@ supported_formats!(
             serde_cbor::from_slice(&hex)?
         },
         |languages| {
-            let cbor: Vec<u8> = languages.to_cbor()?;
+            extern crate hex;
 
-            let mut s = String::new();
-            for byte in cbor {
-                s.push_str(&format!("{:02x}", byte))
-            }
-            s
+            let cbor = languages.to_cbor()?;
+            hex::encode(cbor)
          },
 
     (json, "json", Json) =>

--- a/src/input.rs
+++ b/src/input.rs
@@ -165,10 +165,9 @@ supported_formats!(
         },
 );
 
-pub fn add_input(input: &str, languages: &mut Languages) {
+pub fn add_input(input: &str, languages: &mut Languages) -> bool {
     use std::fs::File;
     use std::io::Read;
-    use std::process;
 
     let map = match File::open(input) {
         Ok(mut file) => {
@@ -196,31 +195,9 @@ pub fn add_input(input: &str, languages: &mut Languages) {
 
     if let Some(map) = map {
         *languages += map;
+        true
     } else {
-        eprintln!("Error:\n Failed to parse input file: {}", input);
-
-        let not_supported = self::Format::not_supported();
-        if !not_supported.is_empty() {
-            eprintln!("
-This version of tokei was compiled without serialization support for the following formats:
-
-    {not_supported}
-
-You may want to install any comma separated combination of {all:?}:
-
-    cargo install tokei --features {all:?}
-
-Or use the 'all' feature:
-
-    cargo install tokei --features all
-    \n",
-                not_supported = not_supported.join(", "),
-                // no space after comma to ease copypaste
-                all = self::Format::all().join(",")
-            );
-        }
-
-        process::exit(1);
+        false
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::str::FromStr;
 use std::error::Error;
 use std::collections::BTreeMap;
@@ -132,8 +133,8 @@ supported_formats!(
         },
         |languages| {
             extern crate hex;
-
-            let cbor = languages.to_cbor()?;
+            extern crate serde_cbor;
+            let cbor = serde_cbor::to_vec(&languages)?;
             hex::encode(cbor)
          },
 
@@ -143,7 +144,8 @@ supported_formats!(
             serde_json::from_str(&input)?
         },
         |languages| {
-            languages.to_json()?
+            extern crate serde_json;
+            serde_json::to_string(&languages)?
         },
 
     (yaml, "yaml", Yaml) =>
@@ -152,16 +154,18 @@ supported_formats!(
             serde_yaml::from_str(&input)?
         },
         |languages| {
-            languages.to_yaml()?
+            extern crate serde_yaml;
+            serde_yaml::to_string(&languages)?
         },
 
     (toml, "toml-io", Toml) =>
         |input| {
             extern crate toml;
-            toml::from_str(&input)
+            toml::from_str(&input)?
         },
         |languages| {
-            languages.to_toml()?
+            extern crate toml;
+            toml::to_string(&languages)?
         },
 );
 

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -264,7 +264,7 @@ impl Languages {
     ///
     /// assert_eq!(empty_map.len(), 0);
     /// ```
-    fn remove_empty(&self) -> BTreeMap<&LanguageType, &Language> {
+    pub fn remove_empty(&self) -> BTreeMap<&LanguageType, &Language> {
         let mut map = BTreeMap::new();
 
         for (name, language) in &self.inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,14 +62,6 @@ extern crate serde_derive;
 
 #[cfg(feature = "io")]
 extern crate serde;
-#[cfg(feature = "cbor")]
-extern crate serde_cbor;
-#[cfg(feature = "json")]
-extern crate serde_json;
-#[cfg(feature = "yaml")]
-extern crate serde_yaml;
-#[cfg(feature = "toml-io")]
-extern crate toml;
 
 #[macro_use]
 mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,22 +10,14 @@ extern crate tokei;
 mod input;
 use input::*;
 
-use std::borrow::Cow;
 use std::str::FromStr;
 use std::process;
 
-use env_logger::Builder;
-use log::LevelFilter;
-
 use tokei::{Languages, Language, LanguageType};
-use tokei::Sort::*;
+use tokei::Sort;
 use input::Format;
 
-const BLANKS: &str = "blanks";
-const CODE: &str = "code";
-const COMMENTS: &str = "comments";
 const FILES: &str = "files";
-const LINES: &str = "lines";
 const ROW: &str = "------------------------------------------------------------\
                    -------------------";
 
@@ -35,6 +27,22 @@ fn crate_version() -> String {
     }
 
     format!("{} compiled with serialization support: {}", crate_version!(), Format::supported().join(", "))
+}
+
+fn setup_logger(verbose_option: u64) {
+    use log::LevelFilter;
+
+    let mut builder = env_logger::Builder::new();
+
+    let filter_level = match verbose_option {
+        1 => LevelFilter::Warn,
+        2 => LevelFilter::Debug,
+        3 => LevelFilter::Trace,
+        _ => LevelFilter::Error,
+    };
+
+    builder.filter(None, filter_level);
+    builder.init();
 }
 
 fn print_input_parse_failure(input_filename: &str) {
@@ -62,6 +70,21 @@ Or use the 'all' feature:
     }
 }
 
+fn print_supported_languages() {
+    for key in LanguageType::list() {
+        println!("{:<25}", key);
+    }
+}
+
+fn parse_or_exit<T>(s: &str) -> T
+where T: FromStr,
+      T::Err: std::fmt::Display {
+    T::from_str(s).unwrap_or_else(|e| {
+        eprintln!("Error:\n{}", e);
+        std::process::exit(1);
+    })
+}
+
 fn main() {
     // Get options at the beginning, so the program doesn't have to make any
     // extra calls to get the information, and there isn't any magic strings.
@@ -86,7 +109,7 @@ fn main() {
     let files_option = matches.is_present(FILES);
     let input_option = matches.value_of("file_input");
     let output_option = matches.value_of("output");
-    let language_option = matches.is_present("languages");
+    let print_languages_option = matches.is_present("languages");
     let verbose_option = matches.occurrences_of("verbose");
     let sort_option = matches.value_of("sort");
     let ignored_directories = {
@@ -97,32 +120,19 @@ fn main() {
         ignored_directories
     };
 
-    let output_format = output_option.map(|s| {
-        Format::from_str(s).unwrap_or_else(|e| {
-            eprintln!("Error:\n{}", e);
-            std::process::exit(1);
-        })
-    });
+    // Sorting category should be restricted by clap but parse before we do work just in case.
+    let sort_category = sort_option.map(parse_or_exit::<Sort>);
+    // Format category is overly accepting by clap (so the user knows what is supported)
+    // but this will fail if support is not compiled in and give a useful error to the user.
+    let output_format = output_option.map(parse_or_exit::<Format>);
 
-    let mut builder = Builder::new();
-
-    let filter_level = match verbose_option {
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Debug,
-        3 => LevelFilter::Trace,
-        _ => LevelFilter::Error,
-    };
-
-    builder.filter(None, filter_level);
-    builder.init();
+    setup_logger(verbose_option);
 
     let mut languages = Languages::new();
 
-    if language_option {
-        for key in LanguageType::list() {
-            println!("{:<25}", key);
-        }
-        return;
+    if print_languages_option {
+        print_supported_languages();
+        process::exit(0);
     }
 
     let paths: Vec<&str> = match matches.values_of("input") {
@@ -154,60 +164,27 @@ fn main() {
                 "Blanks");
     println!("{}", ROW);
 
-    if let Some(sort_category) = sort_option {
-
+    if let Some(sort_category) = sort_category {
         for (_, ref mut language) in &mut languages {
-            match &*sort_category {
-                BLANKS => language.sort_by(Blanks),
-                COMMENTS => language.sort_by(Comments),
-                CODE => language.sort_by(Code),
-                FILES => language.sort_by(Files),
-                LINES => language.sort_by(Lines),
-                _ => unreachable!(),
-            }
+            language.sort_by(sort_category)
         }
 
         let mut languages: Vec<_> = languages.iter().collect();
 
-        match &*sort_category {
-            BLANKS => languages.sort_by(|a, b| b.1.blanks.cmp(&a.1.blanks)),
-            COMMENTS => languages.sort_by(|a, b| b.1.comments.cmp(&a.1.comments)),
-            CODE => languages.sort_by(|a, b| b.1.code.cmp(&a.1.code)),
-            FILES => languages.sort_by(|a, b| b.1.stats.len().cmp(&a.1.stats.len())),
-            LINES => languages.sort_by(|a, b| b.1.lines.cmp(&a.1.lines)),
-            _ => unreachable!(),
+        match sort_category {
+            Sort::Blanks => languages.sort_by(|a, b| b.1.blanks.cmp(&a.1.blanks)),
+            Sort::Comments => languages.sort_by(|a, b| b.1.comments.cmp(&a.1.comments)),
+            Sort::Code => languages.sort_by(|a, b| b.1.code.cmp(&a.1.code)),
+            Sort::Files => languages.sort_by(|a, b| b.1.stats.len().cmp(&a.1.stats.len())),
+            Sort::Lines => languages.sort_by(|a, b| b.1.lines.cmp(&a.1.lines)),
         }
 
-        for (name, language) in languages {
-            if !language.is_empty() {
-                if !files_option {
-                    print_language(language, name);
-                } else {
-                    print_language(language, name);
-                    println!("{}", ROW);
-                    for file in &language.stats {
-                        println!("{}", file);
-                    }
-                    println!("{}", ROW);
-                }
-            }
-        }
+        print_results(languages.into_iter(), files_option)
     } else  {
-        for (name, language) in languages.iter().filter(isnt_empty) {
-            if files_option {
-                print_language(language, name);
-                println!("{}", ROW);
-
-                for stat in &language.stats {
-                    println!("{}", stat);
-                }
-                println!("{}", ROW);
-            } else  {
-                print_language(language, name);
-            }
-        }
+        print_results(languages.iter(), files_option)
     }
 
+    // If we're listing files there's already a trailing row so we don't want an extra one.
     if !files_option {
         println!("{}", ROW);
     }
@@ -215,25 +192,33 @@ fn main() {
     for (_, language) in languages {
         total += language;
     }
-    println!(" {: <18} {: >6} {:>12} {:>12} {:>12} {:>12}",
-             "Total",
-             total.stats.len(),
-             total.lines,
-             total.code,
-             total.comments,
-             total.blanks);
+
+    print_language(&total, "Total");
     println!("{}", ROW);
+}
+
+fn print_results<'a, I>(languages: I, list_files: bool)
+where I: std::iter::Iterator<Item = (&'a LanguageType, &'a Language)> {
+    for (name, language) in languages.filter(isnt_empty) {
+        print_language(language, name.name());
+
+        if list_files {
+            println!("{}", ROW);
+            for stat in &language.stats {
+                println!("{}", stat);
+            }
+            println!("{}", ROW);
+        }
+    }
 }
 
 fn isnt_empty(&(_, language): &(&LanguageType, &Language)) -> bool {
     !language.is_empty()
 }
 
-fn print_language<'a, C>(language: &'a Language, name: C)
-    where C: Into<Cow<'a, LanguageType>>
-{
+fn print_language(language: &Language, name: &str) {
     println!(" {: <18} {: >6} {:>12} {:>12} {:>12} {:>12}",
-             name.into().name(),
+             name,
              language.stats.len(),
              language.lines,
              language.code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ Or use the 'all' feature:
     \n",
             not_supported = not_supported.join(", "),
             // no space after comma to ease copypaste
-            all = self::Format::all().join(",")
+            all = self::Format::all_feature_names().join(",")
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,8 @@ fn crate_version() -> String {
         return crate_version!().into()
     }
 
-    format!("{} compiled with serialization support: {}", crate_version!(), Format::supported().join(", "))
+    format!("{} compiled with serialization support: {}",
+        crate_version!(), Format::supported().join(", "))
 }
 
 fn setup_logger(verbose_option: u64) {
@@ -93,18 +94,36 @@ fn main() {
         (version: &*crate_version())
         (author: "Aaron P. <theaaronepower@gmail.com> + Contributors")
         (about: crate_description!())
-        (@arg exclude: -e --exclude +takes_value +multiple number_of_values(1) "Ignore all files & directories containing the word.")
-        (@arg file_input: -i --input +takes_value "Gives statistics from a previous tokei run. Can be given a file path, or \"stdin\" to read from stdin.")
-        (@arg files: -f --files "Will print out statistics on individual files.")
-        (@arg input: conflicts_with[languages] ... "The input file(s)/directory(ies) to be counted.")
-        (@arg languages: -l --languages conflicts_with[input] "Prints out supported languages and their extensions.")
-        (@arg output: -o --output possible_values(/* `all` is used so we can fail later with a better error */Format::all()) +takes_value
-            "Outputs Tokei in a specific format. Compile with additional features for more format support.")
-        (@arg verbose: -v --verbose ... "Set log output level:
+        (@arg exclude: -e --exclude
+            +takes_value
+            +multiple number_of_values(1)
+            "Ignore all files & directories containing the word.")
+        (@arg file_input: -i --input
+            +takes_value
+            "Gives statistics from a previous tokei run. Can be given a file path, \
+            or \"stdin\" to read from stdin.")
+        (@arg files: -f --files
+            "Will print out statistics on individual files.")
+        (@arg input:
+            conflicts_with[languages] ...
+            "The input file(s)/directory(ies) to be counted.")
+        (@arg languages: -l --languages
+            conflicts_with[input]
+            "Prints out supported languages and their extensions.")
+        (@arg output: -o --output
+            possible_values(/* `all` is used so to fail later with a better error */Format::all())
+            +takes_value
+            "Outputs Tokei in a specific format. Compile with additional features for more \
+            format support.")
+        (@arg verbose: -v --verbose ...
+        "Set log output level:
          1: to show unknown file extensions,
          2: reserved for future debugging,
          3: enable file level trace. Not recommended on multiple files")
-        (@arg sort: -s --sort possible_values(&["files", "lines", "blanks", "code", "comments"]) +takes_value "Sort languages based on column")
+        (@arg sort: -s --sort
+            possible_values(&["files", "lines", "blanks", "code", "comments"])
+            +takes_value
+            "Sort languages based on column")
     ).get_matches();
     let files_option = matches.is_present(FILES);
     let input_option = matches.value_of("file_input");

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::str::FromStr;
 
 /// Used for sorting languages.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -13,6 +14,21 @@ pub enum Sort {
     Files,
     /// Sort by number of lines.
     Lines,
+}
+
+impl FromStr for Sort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "blanks" => Sort::Blanks,
+            "comments" => Sort::Comments,
+            "code" => Sort::Code,
+            "files" => Sort::Files,
+            "lines" => Sort::Lines,
+            s => return Err(format!("Unsupported sorting option: {}", s))
+        })
+    }
 }
 
 impl<'a> From<Sort> for Cow<'a, Sort> {


### PR DESCRIPTION
Went a bit deeper on this than planned, I'm trying to work towards having a `--stream-output` option so I can use tokei to just stream me a bunch of filenames with their stats (not interested in the summary) but I got stuck refactoring a bit of stuff as I was trying to understand how the library was working. 

The previous method of handling formats was quite hard to know when you've missed a method if you want to add a new type and it wasn't easy to get the error messages correct. In theory now someone can use tokei as a library and serialize with whatever format they want using the serde traits directly.

I'm probably going to continue onto making changes to the main library but I felt like this was a good point to check in to see if what I've done already would be wanted upstream or not :) 

I did notice there's some weird behavior currently that is broken even on a cargo-installed version that I'm not sure how you want it to behave: 
- what is `--input` meant to actually do, it never seems to add results to a scan when I try it?
- is there a limitation on toml support? I can't find any directory that it works on without giving me a 'key was not a string' error