### PR TITLE
add support for more languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ with the following information. If you're unsure have a look at
 - The string literal syntax
 
 ```
+ABAP
 ActionScript
 Ada
 Alex
@@ -289,6 +290,7 @@ Cassius
 Ceylon
 Clojure
 CMake
+COBOL
 CoffeeScript
 Cogent
 ColdFusion
@@ -315,6 +317,7 @@ FORTRAN Modern
 GDScript
 GLSL
 Go
+Groovy
 Happy
 Handlebars
 Haskell

--- a/languages.json
+++ b/languages.json
@@ -1,6 +1,7 @@
 {
     "languages":{
-        "ABAP":{
+        "Abap":{
+            "name":"ABAP",
             "line_comment":[
                 "*",
                 "\\\""
@@ -220,7 +221,8 @@
                 "cmakelists.txt"
             ]
         },
-        "COBOL": {
+        "Cobol": {
+            "name":"COBOL",
             "line_comment":[
                 "*"
             ],

--- a/languages.json
+++ b/languages.json
@@ -1,5 +1,14 @@
 {
     "languages":{
+        "ABAP":{
+            "line_comment":[
+                "*",
+                "\\\""
+            ],
+            "extensions":[
+                "abap"
+            ]
+        },
         "ActionScript":{
             "base":"c",
             "extensions":[
@@ -209,6 +218,18 @@
             ],
             "filenames":[
                 "cmakelists.txt"
+            ]
+        },
+        "COBOL": {
+            "line_comment":[
+                "*"
+            ],
+            "extensions":[
+                "cob",
+                "cbl",
+                "ccp",
+                "cobol",
+                "cpy"
             ]
         },
         "CoffeeScript":{
@@ -536,6 +557,15 @@
             "base":"c",
             "extensions":[
                 "go"
+            ]
+        },
+        "Groovy":{
+            "base":"c",
+            "extensions":[
+                "groovy",
+                "grt",
+                "gtpl",
+                "gvy"
             ]
         },
         "Happy":{


### PR DESCRIPTION
Add support for three languages:
- ABAP (.abap)
- COBOL (.cob, .cbl, .ccp, .cobol, .cpy)
- Groovy (.groovy, .grt, .gtpl, .gvy)