### PR TITLE
README: remove notice about "unstable" being required for Nix/NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ $ brew install tokei
 
 #### Nix/NixOS
 ```shell
-# using unstable nixpkgs channel
 $ nix-env -i tokei
 ```
 


### PR DESCRIPTION
tokei 7.0.0 is in current stable release-18.03