### PR TITLE
update README.md with how install output features

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,26 @@ Tokei normally outputs into a nice human readable format designed for terminals.
 There is also using the `--output` option various other formats that are more
 useful for bringing the data into another program.
 
+**Note:** This version of tokei was compiled without any serialization formats, to enable serialization, reinstall
+tokei with the features flag.
+
+```shell
+  ALL:
+  cargo install tokei --features all
+
+  JSON:
+  cargo install tokei --features json
+
+  CBOR:
+  cargo install tokei --features cbor
+
+  YAML:
+  cargo install tokei --features yaml
+
+  CBOR:
+  cargo install tokei --features cbor
+```
+
 **Currently supported formats**
 - JSON `--output json`
 - YAML `--output yaml`


### PR DESCRIPTION
Informs the user that additional dependencies must be installed to use the output features. Without this, the user may think that all serialization formats are included without additional installation.