### PR TITLE
Add Racket to the supported languages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Python
 QCL
 QML
 R
+Racket
 Rakefile
 Razor
 ReStructuredText

--- a/languages.json
+++ b/languages.json
@@ -1092,6 +1092,18 @@
                 "r"
             ]
         },
+        "Racket":{
+            "line_comment":[
+                ";"
+            ],
+            "multi_line":[
+                ["#|", "|#"]
+            ],
+            "nested":true,
+            "extensions":[
+                "rkt"
+            ]
+        },
         "Rakefile":{
             "line_comment":[
                 "#"

--- a/tests/data/racket.rkt
+++ b/tests/data/racket.rkt
@@ -1,4 +1,4 @@
-;;; 40 lines 14 code 15 comments 11 blanks
+;;; 40 lines 15 code 14 comments 11 blanks
 #lang racket ; defines the language we are using
 
 ;;; Comments
@@ -12,8 +12,8 @@
     |#
 |#
 
-;; S-expression comments discard the following expression,
-;; useful to comment expressions when debugging
+;; S-expression comments discard the following expression
+;; since this is syntax-aware, tokei counts this as code
 #; (this expression is discarded)
 
 ;; Constant

--- a/tests/data/racket.rkt
+++ b/tests/data/racket.rkt
@@ -1,0 +1,40 @@
+;;; 40 lines 14 code 15 comments 11 blanks
+#lang racket ; defines the language we are using
+
+;;; Comments
+
+;; Single line comments start with a semicolon
+
+#| Block comments
+   can span multiple lines and...
+    #|
+        they can be nested!
+    |#
+|#
+
+;; S-expression comments discard the following expression,
+;; useful to comment expressions when debugging
+#; (this expression is discarded)
+
+;; Constant
+(define %pi 3.14159265358979323846)
+
+#| This is a block comment |#
+(define (degrees->radians deg)
+  (* deg (/ %pi 180)))
+
+;; Function
+(define (sq x) (* x x))
+
+(define (sum xs)
+  "Sum list of elements."
+  (foldl + 0 xs)) ; comment
+
+(define (sum-upto n)
+  (/ (* n (+ 1 n)) 2))
+
+(define (test-sums n)
+  (= (sum-upto n)
+     (sum (range (+ 1 n)))))
+
+(test-sums 100)


### PR DESCRIPTION
This PR would add Racket as a supported language for tokei. It's set up as a copy of the Scheme entry, but with the extension changed to `rkt`. The test file is changed to be valid Racket code.

A complication here is that line 17 of the test file _is_ a valid comment, but it comments out the whole s-expression regardless of how many lines it takes up. I don't believe this is currently possible with tokei, and so this PR does not currently count that line as a comment.