### PR TITLE
Add Forsyth-Edwards-Notation (FEN) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Elm
 Emacs Development Environment
 Emacs Lisp
 Erlang
+FEN
 Forth
 F*
 F#

--- a/languages.json
+++ b/languages.json
@@ -474,6 +474,13 @@
                 "hrl"
             ]
         },
+        "FEN":{
+            "name":"FEN",
+            "base":"blank",
+            "extensions":[
+                "fen"
+            ]
+        },
         "Fstar":{
             "name":"F*",
             "base":"func",


### PR DESCRIPTION
> A FEN "record" defines a particular game position, all in one text line and using only the ASCII character set. A text file with only FEN data records should have the file extension ".fen"

[FEN on Wikipedia](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)

Fairly niche, and not code, so I understand perfectly if you opt to close this PR.

You can see an example file [here](https://github.com/DenialAdams/chessatk/blob/master/tests/positions.fen)

Thanks for your work!