### PR TITLE
Attempt to add PowerShell to languages.json

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1088,6 +1088,22 @@
                 "polly"
             ]
         },
+        "PowerShell":{
+            "line_comment":[
+                "#"
+            ],
+            "multi_line":[
+                ["<#", "#>"]
+            ],
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "ps1",
+                "psm1"
+            ]
+        },
         "Processing":{
             "base":"c",
             "extensions":[


### PR DESCRIPTION
Wasn't entirely sure if I needed to or should have use a "base", but the two main extensions are in there.