### PR TITLE
Liquid template language support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -881,6 +881,20 @@
                 ["'", "'"]
             ]
         },
+        "Liquid": {
+            "name":"Liquid",
+            "base":"html",
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "liquid"
+            ],
+            "multi_line":[
+                ["{% comment %}", "{% endcomment %}"]
+            ]
+        },
         "LinkerScript":{
             "name":"LD Script",
             "base":"c",
@@ -1471,7 +1485,7 @@
             "extensions":[
                 "frm",
                 "bas",
-                "cls" 
+                "cls"
             ]
         },
         "VBScript":{

--- a/tests/data/liquid.liquid
+++ b/tests/data/liquid.liquid
@@ -1,0 +1,24 @@
+{% comment %} 24 lines 19 code 1 comment 4 blanks {% endcomment %}
+
+{% paginate collection.products by 20 %}
+
+<ul id="product-collection">
+    {% for product in collection.products %}
+    <li class="singleproduct clearfix">
+      <div class="small">
+        <div class="prodimage"><a href="{{product.url}}"><img src="{{ product.featured_image | product_img_url: 'small' }}" /></a></div>
+      </div>
+      <div class="description">
+        <h3><a href="{{product.url}}">{{product.title}}</a></h3>
+        <p>{{ product.description | strip_html | truncatewords: 35 }}</p>
+      <p class="money">{{ product.price_min | money }}{% if product.price_varies %} - {{ product.price_max | money }}{% endif %}</p>
+     </div>
+    </li>
+    {% endfor %}
+</ul>
+
+<div id="pagination">
+  {{ paginate | default_pagination }}
+</div>
+
+{% endpaginate %}

--- a/tests/data/liquid.liquid
+++ b/tests/data/liquid.liquid
@@ -1,4 +1,4 @@
-{% comment %} 24 lines 19 code 1 comment 4 blanks {% endcomment %}
+{% comment %} 24 lines 19 code 1 comments 4 blanks {% endcomment %}
 
 {% paginate collection.products by 20 %}
 


### PR DESCRIPTION
Adds support for the Liquid template language. See also:

 - https://shopify.github.io/liquid/
 - https://github.com/Shopify/liquid

Test data file copied from the Liquid project itself, licensed MIT.

https://github.com/Shopify/liquid/blob/master/performance/tests/dropify/collection.liquid