### PR TITLE
Handling verbose argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,16 +33,16 @@ fn main() -> Result<(), Box<Error>> {
             "Gives statistics from a previous tokei run. Can be given a file path, \
             or \"stdin\" to read from stdin.")
         (@arg files: -f --files
-            "Will print out statistics on individual files.")
+            "Prints out statistics on individual files")
         (@arg input:
             conflicts_with[languages] ...
             "The input file(s)/directory(ies) to be counted.")
         (@arg types: -t --type
             +takes_value
-            "Filters output by language type, seperated by a comma. i.e. -t=Rust,Markdown")
+            "Filters output by language type, separated by a comma. e.g. -t=Rust,Markdown")
         (@arg languages: -l --languages
             conflicts_with[input]
-            "Prints out supported languages and their extensions.")
+            "Prints out supported languages and their extensions")
         (@arg output: -o --output
             // `all` is used so to fail later with a better error
             possible_values(Format::all())
@@ -51,9 +51,9 @@ fn main() -> Result<(), Box<Error>> {
             format support.")
         (@arg verbose: -v --verbose ...
         "Set log output level:
-         1: to show unknown file extensions,
-         2: reserved for future debugging,
-         3: enable file level trace. Not recommended on multiple files")
+         1: show unknown file extensions
+         2: reserved for future debugging
+         3: enable file level trace, not recommended on multiple files")
         (@arg sort: -s --sort
             possible_values(&["files", "lines", "blanks", "code", "comments"])
             +takes_value

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,14 @@ fn main() -> Result<(), Box<Error>> {
             +takes_value
             "Outputs Tokei in a specific format. Compile with additional features for more \
             format support.")
-        (@arg verbose: -v --verbose ...
-        "Set log output level:
-         1: show unknown file extensions
-         2: reserved for future debugging
-         3: enable file level trace, not recommended on multiple files")
+        (@arg verbose: -v --verbose
+            possible_values(&["1", "2", "3"])
+            hide_possible_values(true)
+            +takes_value
+            "Set log output level:
+            1: show unknown file extensions
+            2: reserved for future debugging
+            3: enable file level trace, not recommended on multiple files")
         (@arg sort: -s --sort
             possible_values(&["files", "lines", "blanks", "code", "comments"])
             +takes_value
@@ -65,7 +68,11 @@ fn main() -> Result<(), Box<Error>> {
     let output_option = matches.value_of("output");
     let print_languages_option = matches.is_present("languages");
     let sort_option = matches.value_of("sort");
-    let verbose_option = matches.occurrences_of("verbose");
+    let verbose_option = if let Some(level) = matches.value_of("verbose") {
+        parse_or_exit::<u64>(level)
+    } else {
+        0
+    };
     let ignored_directories = {
         let mut ignored_directories: Vec<&str> = Vec::new();
         if let Some(user_ignored) = matches.values_of("exclude") {


### PR DESCRIPTION
This changes the functionality of the `--verbose` flag to what seems to be intended (see #242). Before this change you need to specify the logging levels by the number of `-v`'s you added to the command.

For example, the old way of specifying logging level 3 would be `tokei -v -v -v`. This change makes the invocation `tokei -v 3`.

Closes #242