### PR TITLE
Let --sort argument be case insensitive.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> Result<(), Box<Error>> {
          3: enable file level trace. Not recommended on multiple files")
         (@arg sort: -s --sort
             possible_values(&["files", "lines", "blanks", "code", "comments"])
+            case_insensitive(true)
             +takes_value
             "Sort languages based on column")
     ).get_matches();

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -20,7 +20,7 @@ impl FromStr for Sort {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+        Ok(match s.to_lowercase().as_ref() {
             "blanks" => Sort::Blanks,
             "comments" => Sort::Comments,
             "code" => Sort::Code,


### PR DESCRIPTION
Allows the `--sort` argument to be case insensitive. Since the column names are capitalized in the output, this makes it a little more natural so that you can actually use the printed column names as the argument to sort.