### PR TITLE
Add language rules for Perl6 and its cousin Not Quite Perl

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1092,6 +1092,22 @@
                 "pm"
             ]
         },
+        "Perl6":{
+            "line_comment":[
+                "#"
+            ],
+            "multi_line":[
+                ["=begin", "=end"]
+            ],
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "pl6",
+                "pm6"
+            ]
+        },
         "Php":{
             "name":"PHP",
             "line_comment":[

--- a/languages.json
+++ b/languages.json
@@ -1108,6 +1108,22 @@
                 "pm6"
             ]
         },
+        "NotQuitePerl":{
+            "name": "Not Quite Perl",
+            "line_comment":[
+                "#"
+            ],
+            "multi_line":[
+                ["=begin", "=end"]
+            ],
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "nqp"
+            ]
+        },
         "Php":{
             "name":"PHP",
             "line_comment":[

--- a/tests/data/nqp.nqp
+++ b/tests/data/nqp.nqp
@@ -1,0 +1,24 @@
+# 24 lines 15 code 7 comments 2 blanks
+=begin
+Regex methods and functions
+=end
+
+=begin item match
+Match C<$text> against C<$regex>.  If the C<$global> flag is
+given, then return an array of all non-overlapping matches.
+=end item
+
+sub match ($text, $regex, :$global?) {
+    my $match := $text ~~ $regex;
+    if $global {
+        my @matches;
+        while $match {
+            nqp::push(@matches, $match);
+            $match := $match.parse($text, :rule($regex), :c($match.to));
+        }
+        @matches;
+    }
+    else {
+        $match;
+    }
+}

--- a/tests/data/perl6.pl6
+++ b/tests/data/perl6.pl6
@@ -1,4 +1,4 @@
-# 11 lines 5 code 4 comments 3 blanks
+# 11 lines 5 code 4 comments 2 blanks
 
 =begin pod
 Defines a fun infix operator.

--- a/tests/data/perl6.pl6
+++ b/tests/data/perl6.pl6
@@ -1,0 +1,11 @@
+# 11 lines 5 code 4 comments 3 blanks
+
+=begin pod
+Defines a fun infix operator.
+This was stolen from http://tpm2016.zoffix.com/#/14
+=end pod
+sub infix:<¯\(°_o)/¯> {
+    ($^a, $^b).pick
+}
+
+say 'Coke' ¯\(°_o)/¯ 'Pepsi';


### PR DESCRIPTION
Perl6 is just slightly different from Perl 5, with the multline comments starting/ending with `=begin` and `=end` instead of `=pod` and `=cut`.

I have not written Not Quite Perl at all, but it is the language that Perl6 is written in and has very similar syntax, and effectively identical comment syntax.

The tests for these are not entirely accurate. Perl6 allows for multiline comments to have a "tag" of sorts, e.g.

```perl6
=begin item match
Documentation for match here
=end item
```

where "item" is the tag. While one would normally include the `=end item` to be part of the multiline comment, tokei only ends at the `=end` token. Is it possible to define regular expressions for multiline comments? I have not looked too closely at the source.