### PR TITLE
Add SWIG support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1442,6 +1442,15 @@
                 "swift"
             ]
         },
+        "Swig":{
+            "name":"SWIG",
+            "base":"c",
+            "nested":true,
+            "extensions":[
+                "swg",
+                "i"
+            ]
+        },
         "SystemVerilog":{
             "base":"c",
             "extensions":[

--- a/tests/data/swig.i
+++ b/tests/data/swig.i
@@ -1,0 +1,16 @@
+/* 16 lines 8 code 5 comments 3 blanks */
+%module mymodule
+
+/*
+ * Wrapper-includes
+ */
+%{
+#include "myheader.h" //dummy header
+%}
+
+// Now list ANSI C/C++ declarations
+int foo;
+int bar(int x);
+
+%rename(my_print) print;
+extern void print(const char *);


### PR DESCRIPTION
Hi !
I added the definition for SWIG files (Simplified Wrapper and Interface Generator, [http://swig.org/](http://swig.org/)). It's a wrapper generator used to embed C/C++ code in projects written in other languages.

The syntax is normal C/C++ with added annotations (beginning by `%`).