### PR TITLE
Don't use width larger than 79 by default

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,11 +63,17 @@ impl<'a> Cli<'a> {
             3: enable file level trace. Not recommended on multiple files")
         ).get_matches();
 
-        let columns = matches.value_of("columns").and_then(|s| s.parse().ok())
+        let columns = matches.value_of("columns").map(parse_or_exit::<usize>)
             .unwrap_or_else(|| {
-                ::term_size::dimensions().map_or(FALLBACK_ROW_LEN, |(w, _)| {
-                    w.max(FALLBACK_ROW_LEN)
-                })
+                // If user passed `--files`, we output file paths and want to
+                // use all available width.
+                if matches.is_present("files") {
+                    ::term_size::dimensions().map_or(FALLBACK_ROW_LEN, |(w, _)| {
+                        w.max(FALLBACK_ROW_LEN)
+                    })
+                } else {
+                    FALLBACK_ROW_LEN
+                }
             });
 
 


### PR DESCRIPTION
closes https://github.com/Aaronepower/tokei/issues/277

I don't really understand the code, so this may be completely stupid, but why do we even try to make output wider than 79 characters by default?

I think it might make sense to try to make it *narrower* than 79 if the terminal itself is narrow, but if it is wide, it makes little sense to try to fill it completely.