### PR TITLE
Adding "vhdl" file extension for VHDL files

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1634,7 +1634,8 @@
                 "--"
             ],
             "extensions":[
-                "vhd"
+                "vhd",
+                "vhdl"
             ]
         },
         "VisualBasic":{


### PR DESCRIPTION
VHDL files could be named with ".vhdl" extension as well as ".vhd"