### PR TITLE
Add Stratego language, also known as Stratego/XT

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1431,6 +1431,19 @@
                 "srt"
             ]
         },
+        "Stratego":{
+            "name":"Stratego/XT",
+            "base":"c",
+            "quotes":[
+              ["\\\"", "\\\""],
+              ["$[", "]"],
+              ["$<", ">" ],
+              [ "${", "}" ]
+            ],
+            "extensions":[
+                "str"
+            ]
+        },
         "Svg":{
             "name":"SVG",
             "base":"html",

--- a/tests/data/stratego.str
+++ b/tests/data/stratego.str
@@ -1,0 +1,24 @@
+// 24 lines 12 code 6 comments 6 blanks
+module stratego
+
+strategies
+
+/** // */
+main =
+  !"/* "
+  ; id // */
+
+foo =
+  ?'a'
+
+rules
+
+foobar: "//" -> "\\" // " '
+/* " ' */
+
+foo: a -> a // /*
+where
+  b := 'b' // */
+// ; c := $[quotes with anti quotes [b], which are not supported by tokei atm so this is a commented line of code]
+// ; c := ${quotes with anti quotes {b}, which are not supported by tokei atm so this is a commented line of code}
+// ; c := $<quotes with anti quotes <b>, which are not supported by tokei atm so this is a commented line of code>


### PR DESCRIPTION
[Old website](http://strategoxt.org/), [New website](http://www.metaborg.org/en/latest/source/langdev/meta/lang/stratego/index.html). Related issue mentioned in the test file about anti-quoting is #295. 