### PR TITLE
Feat: add Docker container instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ $ brew install tokei
 $ nix-env -i tokei
 ```
 
+### In a container
+
+Launch the Docker container by supplying the path as a volume in read only mode:
+
+```shell
+$ docker run -v ~/Development/code/myproject/foo:/data:ro mbologna/docker-tokei     
+```
+
 ### Manual
 You can download prebuilt binaries in the
 [releases section](https://github.com/Aaronepower/tokei/releases), or create

--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ $ nix-env -i tokei
 Launch the Docker container by supplying the path as a volume in read only mode:
 
 ```shell
-$ docker run -v ~/Development/code/myproject/foo:/data:ro mbologna/docker-tokei     
+$ docker run -v ~/Development/code/myproject/foo:/data:ro mbologna/docker-tokei
+```
+or
+```shell
+$ docker run -v ~/Development/code/myproject/foo:/data:ro mbologna/docker-tokei tokei --sort lines
 ```
 
 ### Manual


### PR DESCRIPTION
I created a project to containerize tokei:

https://hub.docker.com/r/mbologna/docker-tokei

and with this PR I am adding instructions on how to use the container: you don't have to install anything (aisde from Docker) if you follow this method. This is why I added a new "In a container" section in the README.